### PR TITLE
fix: support cosmwasm environment of Finschia

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,10 @@
 [workspace]
 resolver = "2"
 members = ["packages/*"]
+
+[workspace.dependencies]
+cosmwasm-std = "=1.1.9"
+
+[patch.crates-io]
+cosmwasm-std = { git = "https://github.com/Finschia/cosmwasm", tag = "v1.1.9+0.8.1" }
+home = { git = "https://github.com/rust-lang/cargo.git", tag = "home-0.5.5" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -2,23 +2,26 @@
 members = ["contracts/*"]
 
 [workspace.package]
-version       = "0.1.0"
-edition       = "2021"
-license       = "Apache-2.0"
-repository    = "https://github.com/Finschia/fnsa-contracts"
-homepage      = "https://cosmwasm.com"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/Finschia/fnsa-contracts"
+homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [workspace.dependencies]
-cosmwasm-schema  = "1.1.9"
-cosmwasm-std     = "1.1.9"
-cosmwasm-storage = "1.1.9"
-cw-storage-plus  = "1.1.0"
-cw2              = "1.1.2"
-finschia-std     = { path = "../packages/finschia-std" }
-schemars         = "0.8.12"
-serde            = { version = "1.0.167", default-features = false, features = ["derive"] }
-thiserror        = "1.0.43"
+cosmwasm-schema = "=1.1.9"
+cosmwasm-std = "=1.1.9"
+cw-storage-plus = "=1.1.0"
+cw2 = "=1.1.0"
+finschia-std = { path = "../packages/finschia-std" }
+schemars = "0.8.12"
+serde = { version = "1.0.167", default-features = false, features = ["derive"] }
+thiserror = "1.0.43"
+
+[patch.crates-io]
+cosmwasm-schema = { git = "https://github.com/Finschia/cosmwasm", tag = "v1.1.9+0.8.1" }
+cosmwasm-std = { git = "https://github.com/Finschia/cosmwasm", tag = "v1.1.9+0.8.1" }
 
 [profile.release]
 rpath = false

--- a/examples/contracts/collection/Cargo.toml
+++ b/examples/contracts/collection/Cargo.toml
@@ -1,14 +1,12 @@
 [package]
-name          = "collection"
-description   = "Example collection to use finschia-wasm"
-authors       = [
-  "dudong2 <leesj9476lsj@gmail.com>",
-]
-version       = { workspace = true }
-edition       = { workspace = true }
-license       = { workspace = true }
-repository    = { workspace = true }
-homepage      = { workspace = true }
+name = "collection"
+description = "Example collection to use finschia-wasm"
+authors = ["dudong2 <leesj9476lsj@gmail.com>"]
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
 documentation = { workspace = true }
 
 [lib]
@@ -21,13 +19,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-schema  = { workspace = true }
-cosmwasm-std     = { workspace = true }
-cosmwasm-storage = { workspace = true }
-cw-storage-plus  = { workspace = true }
-cw2              = { workspace = true }
-finschia-std     = { workspace = true }
-schemars         = { workspace = true }
-serde            = { workspace = true }
-thiserror        = { workspace = true }
-
+cosmwasm-schema = { workspace = true }
+cosmwasm-std = { workspace = true }
+cw-storage-plus = { workspace = true }
+cw2 = { workspace = true }
+finschia-std = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }

--- a/packages/finschia-std-derive/Cargo.toml
+++ b/packages/finschia-std-derive/Cargo.toml
@@ -21,7 +21,7 @@ quote = "1.0.20"
 syn = "1.0.98"
 
 [dev-dependencies]
-cosmwasm-std = {version = "1.1.2", features = ["stargate"]}
+cosmwasm-std = { workspace = true, features = ["stargate"] }
 prost = "0.11"
 serde = "1.0.142"
-trybuild = {version = "1.0.63", features = ["diff"]}
+trybuild = { version = "1.0.63", features = ["diff"] }

--- a/packages/finschia-std/Cargo.toml
+++ b/packages/finschia-std/Cargo.toml
@@ -6,13 +6,15 @@ name = "finschia-std"
 version = "0.21.0"
 
 [dependencies]
-chrono = {version = "0.4.27", default-features = false}
-cosmwasm-std = {version = "1.4.0", features = ["stargate"]}
-finschia-std-derive = {version = "0.20.1", path = "../finschia-std-derive" }
-prost = {version = "0.12.3", default-features = false, features = ["prost-derive"]}
-prost-types = {version = "0.12.3", default-features = false}
+chrono = { version = "0.4.27", default-features = false }
+cosmwasm-std = { workspace = true, features = ["stargate"] }
+finschia-std-derive = { version = "0.20.1", path = "../finschia-std-derive" }
+prost = { version = "0.12.3", default-features = false, features = [
+    "prost-derive",
+] }
+prost-types = { version = "0.12.3", default-features = false }
 schemars = "0.8.8"
 
 # for query
-serde = {version = "1.0", default-features = false, features = ["derive"]}
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-cw-value = "0.7.0"

--- a/packages/finschia-std/tests/addional_fields.rs
+++ b/packages/finschia-std/tests/addional_fields.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{from_json, to_json_binary};
+use cosmwasm_std::{from_binary, to_binary};
 use finschia_std_derive::CosmwasmExt;
 use prost::Message;
 
@@ -43,8 +43,8 @@ fn test_additional_fields_does_not_break_but_cause_lossy_json_deserialization() 
     };
 
     // to_binary() and from_binary() is using `serde_json_wasm` under the hood.
-    let serialized = to_json_binary(&response.params.unwrap()).unwrap();
-    let deserialized: Params = from_json(&serialized).unwrap();
+    let serialized = to_binary(&response.params.unwrap()).unwrap();
+    let deserialized: Params = from_binary(&serialized).unwrap();
 
     // lossy deserialization
     assert_eq!(

--- a/packages/proto-build/Cargo.toml
+++ b/packages/proto-build/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
-authors = ["Supanat Potiwarakorn <boss@osmosis.team>", "Justin Kilpatrick <justin@althea.net>", "Tony Arcieri <tony@iqlusion.io>"]
+authors = [
+    "Supanat Potiwarakorn <boss@osmosis.team>",
+    "Justin Kilpatrick <justin@althea.net>",
+    "Tony Arcieri <tony@iqlusion.io>",
+]
 edition = "2021"
 name = "proto-build"
 publish = false
@@ -17,7 +21,7 @@ prost-build = "0.10"
 prost-types = "0.10"
 quote = "1.0.26"
 regex = "1"
-syn = {version = "1.0.98", features = ["full", "parsing", "extra-traits"]}
+syn = { version = "1.0.98", features = ["full", "parsing", "extra-traits"] }
 tonic = "0.7"
 tonic-build = "0.7"
 walkdir = "2"


### PR DESCRIPTION
This PR enable to support cosmwasm environment of Finschia (rust 1.69 and [packages](https://github.com/Finschia/cw-workspace/blob/main/Cargo.toml#L15-L49)). Home package is fixed to the version that support rust 1.69.

close: #6 