### PR TITLE
Fix lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,11 +14,12 @@ jobs:
         with:
           submodules: recursive
       - uses: ./.github/actions/cache
-      - run: |
-          rustup toolchain add 1.69.0
-          rustup override set 1.69.0
-          rustup component add clippy --toolchain 1.69.0-x86_64-unknown-linux-gnu
-          rustup component add rustfmt --toolchain 1.69.0-x86_64-unknown-linux-gnu
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: 1.69.0
+            override: true
+            components: rustfmt, clippy
       - name: fmt
         run: |
           cargo fmt --all -- --check

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.69.0
+            toolchain: 1.70.0
             override: true
             components: rustfmt, clippy
       - name: fmt

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,5 +22,4 @@ jobs:
         # Check by `clippy` even if the previous step fails
         if: success() || failure()
         run: |
-          # `finschia-std` is excluded because of https://github.com/Finschia/finschia-wasm/issues/39
-          cargo clippy --workspace --exclude finschia-std --all-targets --all-features -- -D warnings
+          cargo clippy --all -- -D warnings

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,11 @@ jobs:
         with:
           submodules: recursive
       - uses: ./.github/actions/cache
-      - run: rustup component add rustfmt
+      - run: |
+          rustup toolchain add 1.69.0
+          rustup override set 1.69.0
+          rustup component add clippy --toolchain 1.69.0-x86_64-unknown-linux-gnu
+          rustup component add rustfmt --toolchain 1.69.0-x86_64-unknown-linux-gnu
       - name: fmt
         run: |
           cargo fmt --all -- --check

--- a/packages/proto-build/src/git.rs
+++ b/packages/proto-build/src/git.rs
@@ -8,7 +8,7 @@ pub fn checkout_submodule(dir: &str, rev: &str) {
     let err_msg = format!("Checkout Error; Path: {}", &full_path_dir);
     cmd_git
         .arg("-C")
-        .arg(&full_path_dir.clone())
+        .arg(&full_path_dir)
         .arg("checkout")
         .arg(rev)
         .status()

--- a/packages/proto-build/src/main.rs
+++ b/packages/proto-build/src/main.rs
@@ -5,7 +5,6 @@
 
 use std::path::PathBuf;
 
-use dotenvy;
 use proto_build::{
     code_generator::{CodeGenerator, CosmosProject},
     git,
@@ -47,11 +46,11 @@ pub fn generate(version_tags: &HashMap<String, String>) {
 
     // cosmos/ics23 have not supported yet in Finschia. So it is fixed tag as like osmosis.
     let ics23_version = "rust/v0.10.0";
-    git::checkout_submodule(FINSCHIA_SDK_DIR, &finschia_sdk_version);
-    git::checkout_submodule(WASMD_DIR, &wasmd_version);
-    git::checkout_submodule(COMETBFT_DIR, &tendermint_version);
-    git::checkout_submodule(IBC_GO_DIR, &ibc_go_version);
-    git::checkout_submodule(ICS23_DIR, &ics23_version);
+    git::checkout_submodule(FINSCHIA_SDK_DIR, finschia_sdk_version);
+    git::checkout_submodule(WASMD_DIR, wasmd_version);
+    git::checkout_submodule(COMETBFT_DIR, tendermint_version);
+    git::checkout_submodule(IBC_GO_DIR, ibc_go_version);
+    git::checkout_submodule(ICS23_DIR, ics23_version);
 
     let tmp_build_dir: PathBuf = TMP_BUILD_DIR.parse().unwrap();
     let out_dir: PathBuf = OUT_DIR.parse().unwrap();

--- a/packages/proto-build/src/mod_gen.rs
+++ b/packages/proto-build/src/mod_gen.rs
@@ -36,7 +36,7 @@ pub fn generate_mod_file(for_dir: &Path) {
 fn recur_gen_mod(for_dir: &Path, start_dir: &Path, paths: Vec<Vec<String>>, include_file: &str) {
     let uniq_keys = paths
         .iter()
-        .filter_map(|p| (*p).get(0))
+        .filter_map(|p| (*p).first())
         .map(|s| s.to_owned())
         .unique()
         .sorted()
@@ -83,7 +83,7 @@ fn recur_gen_mod(for_dir: &Path, start_dir: &Path, paths: Vec<Vec<String>>, incl
             let paths: Vec<Vec<String>> = paths
                 .iter()
                 // only if head = k
-                .filter(|p| (**p).get(0) == Some(&k))
+                .filter(|p| (**p).first() == Some(&k))
                 // get tail
                 .map(|p| p.split_at(1).1.to_vec())
                 .collect();

--- a/packages/proto-build/src/transformers.rs
+++ b/packages/proto-build/src/transformers.rs
@@ -552,7 +552,7 @@ pub fn append_querier(
         vec![]
     };
 
-    vec![items, querier].concat()
+    [items, querier].concat()
 }
 
 /// This is a hack to fix a clashing name in the stake_authorization module


### PR DESCRIPTION
# Overview
Change the cargo clippy check range from `--all-targets --all-features` to `--all`

This pr changes two:
- `cargo clippy` has the same detection range as `cargo fmt`. Set to `cargo clippy --all -- -D warnings`.
- Fixed the code that caused an error with `cargo clippy --all -- -D warnings`
